### PR TITLE
:recycle: INVALID_RESPONSE_DATA を削除

### DIFF
--- a/packages/api-spec/src/schema.ts
+++ b/packages/api-spec/src/schema.ts
@@ -334,12 +334,12 @@ export interface components {
              * @description エラーコード
              * @enum {string}
              */
-            code: "INVALID_CREDENTIALS" | "INVALID_ACCESS_TOKEN" | "INVALID_RESPONSE_DATA" | "NOT_FOUND" | "ASSETS_REGISTRATION_FAILED" | "INTERNAL_SERVER_ERROR";
+            code: "INVALID_CREDENTIALS" | "INVALID_ACCESS_TOKEN" | "NOT_FOUND" | "ASSETS_REGISTRATION_FAILED" | "INTERNAL_SERVER_ERROR";
             /**
              * @description エラーメッセージ
              * @enum {string}
              */
-            message: "Invalid Credentials" | "Invalid Access Token" | "Invalid Response Data" | "Not Found" | "Assets Registration Failed" | "Internal Server Error";
+            message: "Invalid Credentials" | "Invalid Access Token" | "Not Found" | "Assets Registration Failed" | "Internal Server Error";
         };
         /** @description ログイン成功時のレスポンス */
         LoginSuccessResponse: {

--- a/packages/api-spec/src/schema.yaml
+++ b/packages/api-spec/src/schema.yaml
@@ -239,7 +239,6 @@ components:
           enum:
             - INVALID_CREDENTIALS
             - INVALID_ACCESS_TOKEN
-            - INVALID_RESPONSE_DATA
             - NOT_FOUND
             - ASSETS_REGISTRATION_FAILED
             - INTERNAL_SERVER_ERROR
@@ -249,7 +248,6 @@ components:
           enum:
             - Invalid Credentials
             - Invalid Access Token
-            - Invalid Response Data
             - Not Found
             - Assets Registration Failed
             - Internal Server Error

--- a/packages/server/src/features/user/user.route.ts
+++ b/packages/server/src/features/user/user.route.ts
@@ -1,12 +1,10 @@
 import type { UserInfoResponseType } from '@api-spec/api-types';
 import { eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
-import { safeParse } from 'valibot';
 import { createHonoApp } from '../../app';
 import { users } from '../../db/schema';
 import { jwtAuthMiddleware } from '../../middleware/auth';
 import type { ErrorCause } from '../../middleware/error';
-import { ResponseUserInfoSchema } from './user.schema';
 
 const user = createHonoApp();
 user.use('/*', jwtAuthMiddleware); // アクセストークンの検証
@@ -15,19 +13,15 @@ user.get('/', async (c): Promise<ReturnType<typeof c.json<UserInfoResponseType>>
   const userId = c.get('userId');
 
   const d1 = c.get('d1');
-  const result = await d1.select().from(users).where(eq(users.id, userId)).get();
+  const result = await d1.select({ id: users.id, name: users.name }).from(users).where(eq(users.id, userId)).get();
 
-  // ※認証の先にあるAPIなので、論理的にはユーザが見つからないケースはないはずだが、もしもの場合を考慮して404エラーを返しておく
+  // 認証の先にあるAPIなので、論理的にはユーザが見つからないケースはないはずだが、防御的に404エラーを返しておく
+  // ただし、今後「退会機能」を追加する場合は適切にアクセストークンの無効化を行わなければ、退会済みユーザーのアクセストークンでここまで到達できてしまうため要注意
   if (!result) {
     throw new HTTPException(404, { cause: 'NOT_FOUND' satisfies ErrorCause });
   }
 
-  const parsed = safeParse(ResponseUserInfoSchema, result);
-  if (!parsed.success) {
-    throw new HTTPException(500, { cause: 'INVALID_RESPONSE_DATA' satisfies ErrorCause });
-  }
-
-  return c.json(parsed.output, 200);
+  return c.json(result, 200);
 });
 
 export default user;

--- a/packages/server/src/features/user/user.schema.ts
+++ b/packages/server/src/features/user/user.schema.ts
@@ -1,7 +1,0 @@
-import type { UserInfoResponseType } from '@api-spec/api-types';
-import { type GenericSchema, nanoid, object, pipe, string } from 'valibot';
-
-export const ResponseUserInfoSchema = object({
-  id: pipe(string(), nanoid()),
-  name: string(),
-}) satisfies GenericSchema<UserInfoResponseType>;

--- a/packages/server/src/middleware/error.ts
+++ b/packages/server/src/middleware/error.ts
@@ -20,8 +20,6 @@ export const errorHandlingMiddleware = (
         return c.json({ code: 'INVALID_ACCESS_TOKEN', message: 'Invalid Access Token' }, 401);
       case 'NOT_FOUND':
         return c.json({ code: 'NOT_FOUND', message: 'Not Found' }, 404);
-      case 'INVALID_RESPONSE_DATA':
-        return c.json({ code: 'INVALID_RESPONSE_DATA', message: 'Invalid Response Data' }, 500);
       case 'ASSETS_REGISTRATION_FAILED':
         return c.json({ code: 'ASSETS_REGISTRATION_FAILED', message: 'Assets Registration Failed' }, 500);
       default:

--- a/packages/web/src/app/shared/schemas/api-error.schema.ts
+++ b/packages/web/src/app/shared/schemas/api-error.schema.ts
@@ -5,7 +5,6 @@ import { type GenericSchema, instance, object, picklist, pipe, safeParse, transf
 const ErrorCodeList = [
   'INVALID_CREDENTIALS',
   'INVALID_ACCESS_TOKEN',
-  'INVALID_RESPONSE_DATA',
   'NOT_FOUND',
   'ASSETS_REGISTRATION_FAILED',
   'INTERNAL_SERVER_ERROR',
@@ -13,7 +12,6 @@ const ErrorCodeList = [
 const ErrorMessageList = [
   'Invalid Credentials',
   'Invalid Access Token',
-  'Invalid Response Data',
   'Not Found',
   'Assets Registration Failed',
   'Internal Server Error',


### PR DESCRIPTION
Valibotでデータを検査するのではなく、DBでserectするときに取得するカラムを明示するやり方に変更したため、INVALID_RESPONSE_DATAが不要になった